### PR TITLE
Same height for jme cards within a row

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -101,20 +101,18 @@ body{
     width:100%;
     flex-direction: row;
     justify-content: center;
-    margin: 10px;
 }
 
-.col{
+.col{/*
     display: flex;
     width:100%;
     flex-direction: column;
     justify-content: flex-start;
-    margin: 10px;
+    margin: 10px;*/
 }
 
 .graphics .jme-card, .utils .jme-card{
     width: 20%;
-    height: 100%;
 }
 
 .graphics .jme-card .mdl-card__title, .utils .jme-card .mdl-card__title{
@@ -174,7 +172,6 @@ body{
 
 .jme-card{
     width:100%;
-    height:30%;
     margin: 10px;
 }
 
@@ -202,4 +199,5 @@ footer{
     width:141px;
     margin: auto;
 }
+
 

--- a/stylesheets/small.css
+++ b/stylesheets/small.css
@@ -32,12 +32,12 @@
         margin: 10px;
     }
 
-    .row{
+    .row{/*
         display: flex;
         width:100%;
         flex-direction: row;
         justify-content: center;
-        margin: 10px;
+        margin: 10px;*/
     }
 
     .col{
@@ -45,12 +45,11 @@
         width:100%;
         flex-direction: column;
         justify-content: flex-start;
-        margin: 10px;
+        margin-bottom: : 10px;
     }
 
     .graphics .jme-card, .utils .jme-card{
         width: 30%;
-        height: 100%;
     }
 
     .book{
@@ -64,7 +63,6 @@
 
     .jme-card{
         width:100%;
-        height:30%;
         margin: 10px;
     }
 


### PR DESCRIPTION
I prefer cards having the same height even if some of them have less text than other.

commented out "col" class css because it's used on only one set of jme cards and make the result odd.
also fix the margin on the right of the intro row  and the central row (2&3)

view changes [here](http://dokthar.github.io/jmonkeyengine-ghpage/)
