### PR TITLE
(belated) announcement of the JME 3.7.0-stable release

### DIFF
--- a/content/devlog/jme370.md
+++ b/content/devlog/jme370.md
@@ -1,0 +1,26 @@
+---
+title: "JMonkeyEngine 3.7.0-stable release"
+date: 2025-01-28T08:00:00+00:00
+draft: false
+type: "default"
+layout: "post_layout_default"
+enable_comments: true
+authors:
+    - "stephengold"
+
+tags:
+    - "devlog"
+    - "release"
+    - "blog"
+---
+
+We're proud to announce the release of version 3.7.0-stable of the JMonkeyEngine game engine.
+And here's a big "thank you!" to Adi Barda, who managed that release.
+
+The new release is featured in [version v3.7.0-stable-sdk2 of our Software Development Kit](https://github.com/jMonkeyEngine/sdk/releases/tag/v3.7.0-stable-sdk2).
+Pre-compiled libraries are available from the Maven Central repository under the "org.jmonkeyengine" groupID.
+Release notes are online at https://github.com/jMonkeyEngine/jmonkeyengine/releases/tag/v3.7.0-stable
+
+Development of a 3.8 release has already begun. Ryan McDonough is managing that effort. Please support him in any way you can.
+
+For the latest news and discussion of JMonkeyEngine software development, visit [the Development category at the JME Community Hub/Forum](https://hub.jmonkeyengine.org/c/development-discussion-jme3/9).


### PR DESCRIPTION
After JME v3.7.0-stable was released in October, the dev blog should've been updated, but it wasn't.

This is a partial solution for https://github.com/jMonkeyEngine/jmonkeyengine/issues/2350